### PR TITLE
Add more typographical symbols

### DIFF
--- a/krunner-symbolsrc
+++ b/krunner-symbolsrc
@@ -175,6 +175,9 @@ hotbeverage=☕
 anchor=⚓
 crossedswords=⚔
 atom=⚛
+nobreakspace= 
+ndash=–
+mdash=—
 
 # Official Symbols
 trademark=™


### PR DESCRIPTION
Hi, thanks for the great krunner extensions, it is very handy!

I've added three symbols I often use. I added them to my local `~/.config/krunner-symbolsrc`, however, it may be handy to make them part of the default distribution, as these symbol are often used in typography: non-breaking space ` `, en dash `–` and em dash `—`.