### PR TITLE
Fix compiler warnings and optimize build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,8 @@ mkdir -p build
 cd build
 
 # Build the plugin
-cmake .. -DCMAKE_INSTALL_PREFIX=`kf5-config --prefix` -DQT_PLUGIN_INSTALL_DIR=`kf5-config --qt-plugins`
-make 
+cmake .. -DCMAKE_INSTALL_PREFIX=`kf5-config --prefix` -DQT_PLUGIN_INSTALL_DIR=`kf5-config --qt-plugins` -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
 # Install the plugin (root access because it has to write into /usr)
 sudo make install
 

--- a/symbols.cpp
+++ b/symbols.cpp
@@ -54,7 +54,6 @@ Symbols::Symbols(QObject *parent, const QVariantList &args)
     loadConfig();
 }
 
-Symbols::~Symbols() {}
 
 void Symbols::loadConfig() {
     
@@ -279,6 +278,8 @@ void Symbols::matchUnicode(Plasma::RunnerContext &context)
 void Symbols::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch &match)
 {
     Q_UNUSED(context);
+// Otherwise compiler shows warning that the results of the system() call is ignored
+#pragma GCC diagnostic ignored "-Wunused-result"
 
     if (match.data().toString().compare("open") == 0)
     {
@@ -299,6 +300,7 @@ void Symbols::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch
         // Copy the result to clipboard
         QApplication::clipboard()->setText(match.text());
     }
+#pragma GCC diagnostic pop
 }
 
 /*

--- a/symbols.h
+++ b/symbols.h
@@ -27,11 +27,10 @@ class Symbols : public Plasma::AbstractRunner
 
 public:
     Symbols(QObject *parent, const QVariantList &args);
-    ~Symbols();
+    ~Symbols() override = default;
 
-    void match(Plasma::RunnerContext &);
-    void run(const Plasma::RunnerContext &, const Plasma::QueryMatch &);
-    
+    void match(Plasma::RunnerContext &) override;
+    void run(const Plasma::RunnerContext &, const Plasma::QueryMatch &) override;
 private:
     QMap<QString, QString> symbols;
     QMap<QString, QString> unicodeSymbols;


### PR DESCRIPTION
Hello,

I have added the `-DCMAKE_BUILD_TYPE=Release` flag to the cmake command in the installer,  with this the compiler optimizes the code significantly better (without it a debug build is created).

Additionally the `warning: ‘virtual void Symbols::match(Plasma::RunnerContext&)’ can be marked override [-Wsuggest-override]` compiler warnings have been fixed.

