### PR TITLE
Update default symbol list

### DIFF
--- a/krunner-symbolsrc
+++ b/krunner-symbolsrc
@@ -103,6 +103,7 @@ partialdifferential=∂
 muchlessthan=≪
 lessequal=≤
 lessequals=≤
+muchgreaterthan=≫
 greaterequal=≥
 greaterequals=≥
 almostequal=≈

--- a/krunner-symbolsrc
+++ b/krunner-symbolsrc
@@ -84,11 +84,15 @@ wholenumbers=ℤ
 integers=ℤ
 rationalnumbers=ℚ
 realnumbers=ℝ
+complexnumbers=ℂ
 emptyset=∅
 
 # Mathematical Operators
 plusminus=±
+times=×
+dotproduct=⋅
 division=÷
+divisionslash=∕
 squareroot=√
 sum=∑
 product=∏
@@ -97,8 +101,8 @@ partialdifferential=∂
 
 # Mathematical Relations
 muchlessthan=≪
-lowerequals=≤
-muchgreaterthan=≫
+lessequal=≤
+lessequals=≤
 greaterequal=≥
 greaterequals=≥
 almostequal=≈
@@ -115,6 +119,9 @@ notin=∉
 subsetequals=⊆
 subset=⊂
 strictsubset=⊊
+supersetequals=⊇
+superset=⊃
+strictsuperset=⊋
 intersection=∩
 union=∪
 
@@ -203,7 +210,7 @@ pound=£
 euro=€
 yen=¥
 cent=¢
-micro=µ
+micro=μ
 
 # Dank Memes
 fliptable=(╯°□°）╯︵ ┻━┻


### PR DESCRIPTION
I’ve added some more mathematical symbols. I also renamed `≤` for consistency with the other symbols. The symbol for ‘micro’ has been changed to U+03BC, which is [preferred](https://en.wikipedia.org/wiki/Micro-#Symbol_encoding_in_character_sets).